### PR TITLE
feat add file

### DIFF
--- a/src/test/test3.ts
+++ b/src/test/test3.ts
@@ -1,0 +1,101 @@
+import express, { Request, Response } from "express";
+
+const app = express();
+
+// Wrong status codes for authentication/authorization
+app.get("/resource1", (req: Request, res: Response) => {
+  if (!req.user) {
+    return res.status(403).json({ error: "Authentication required" })
+  }
+
+  if (!hasPermission(req.user, "read_resource")) {
+    return res.status(401).json({ error: "Permission denied" })
+  }
+
+  res.status(200).json({ data: "ok" });
+});
+
+// Using 500 for client errors
+app.post("/resource2", (req: Request, res: Response) => {
+  if (!req.body.name) {
+    return res.status(500).json({ error: "Name is required" })
+  }
+  res.status(201).json({ message: "Created" });
+});
+
+// Wrong 404 usage
+app.get("/resource3/:id", (req: Request, res: Response) => {
+  const resource = findResource(req.params.id);
+  if (!resource) {
+    return res.status(400).json({ error: "Resource not found" })
+  }
+  res.status(200).json(resource);
+});
+
+// ===== GOOD CODE =====
+
+// Correct authentication/authorization codes
+app.get("/resource4", (req: Request, res: Response) => {
+  if (!req.user) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  if (!hasPermission(req.user, "read_resource")) {
+    return res.status(403).json({ error: "Permission denied" })
+  }
+
+  res.status(200).json({ data: "ok" });
+});
+
+// Correct client error code
+app.post("/resource5", (req: Request, res: Response) => {
+  if (!req.body.name) {
+    return res.status(400).json({ error: "Name is required" })
+  }
+  res.status(201).json({ message: "Created" });
+});
+
+// Correct not found
+app.get("/resource6/:id", (req: Request, res: Response) => {
+  const resource = findResource(req.params.id);
+  if (!resource) {
+    return res.status(404).json({ error: "Resource not found" })
+  }
+  res.status(200).json(resource);
+});
+
+// Extra BAD endpoint
+app.put("/resource7/:id", (req: Request, res: Response) => {
+  if (!req.user) {
+    return res.status(403).json({ error: "Unauthorized" })
+  }
+
+  if (!hasPermission(req.user, "edit_resource")) {
+    return res.status(401).json({ error: "Forbidden" })
+  }
+
+  res.status(200).json({ message: "Updated" });
+});
+
+// Extra GOOD endpoint
+app.delete("/resource8/:id", (req: Request, res: Response) => {
+  if (!req.user) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  if (!hasPermission(req.user, "delete_resource")) {
+    return res.status(403).json({ error: "Permission denied" })
+  }
+
+  res.status(204).send();
+});
+
+// Dummy helper functions
+function hasPermission(user: any, permission: string) {
+  return true;
+}
+
+function findResource(id: string) {
+  if (id === "1") return { id: "1", name: "Test" };
+  return null;
+}

--- a/src/test/test3.ts
+++ b/src/test/test3.ts
@@ -27,7 +27,7 @@ app.post("/resource2", (req: Request, res: Response) => {
 app.get("/resource3/:id", (req: Request, res: Response) => {
   const resource = findResource(req.params.id);
   if (!resource) {
-    return res.status(400).json({ error: "Resource not found" })
+    return res.status(404).json({ error: "Resource not found" })
   }
   res.status(200).json(resource);
 });

--- a/src/test/test3.ts
+++ b/src/test/test3.ts
@@ -18,7 +18,7 @@ app.get("/resource1", (req: Request, res: Response) => {
 // Using 500 for client errors
 app.post("/resource2", (req: Request, res: Response) => {
   if (!req.body.name) {
-    return res.status(500).json({ error: "Name is required" })
+    return res.status(400).json({ error: "Name is required" })
   }
   res.status(201).json({ message: "Created" });
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-10 08:50:43 UTC

### Greptile Summary

This PR adds a new TypeScript test file (`src/test/test3.ts`) that demonstrates HTTP status code usage patterns in Express.js applications. The file serves as educational material showing both incorrect and correct implementations of status code handling for common scenarios like authentication, validation errors, and not-found responses. It includes intentionally wrong examples (using 403 instead of 401 for authentication failures, 500 instead of 400 for client errors) followed by corrected versions. The file fits within the existing test directory structure alongside other test files (`test.js`, `test2.ts`) and aligns with the codebase's pattern of including reference and educational materials in the test folder.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| src/test/test3.ts | 5/5 | New educational TypeScript file demonstrating correct and incorrect HTTP status code usage patterns in Express.js |

</details>

### Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only adds educational test content
- Score reflects the addition of non-functional demonstration code that doesn't affect the application's runtime behavior or introduce any breaking changes
- No files require special attention as this is purely educational material in the test directory

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ExpressApp
    participant AuthMiddleware
    participant PermissionCheck
    participant ResourceFinder

    User->>ExpressApp: "GET /resource1"
    ExpressApp->>AuthMiddleware: "Check req.user"
    AuthMiddleware-->>ExpressApp: "User not authenticated"
    ExpressApp->>User: "403 Forbidden (Wrong: should be 401)"

    User->>ExpressApp: "POST /resource2"
    ExpressApp->>ExpressApp: "Validate req.body.name"
    ExpressApp->>User: "500 Internal Server Error (Wrong: should be 400)"

    User->>ExpressApp: "GET /resource3/:id"
    ExpressApp->>ResourceFinder: "findResource(id)"
    ResourceFinder-->>ExpressApp: "Resource not found"
    ExpressApp->>User: "400 Bad Request (Wrong: should be 404)"

    User->>ExpressApp: "GET /resource4"
    ExpressApp->>AuthMiddleware: "Check req.user"
    AuthMiddleware-->>ExpressApp: "User authenticated"
    ExpressApp->>PermissionCheck: "hasPermission(user, 'read_resource')"
    PermissionCheck-->>ExpressApp: "Permission granted"
    ExpressApp->>User: "200 OK with data"

    User->>ExpressApp: "POST /resource5"
    ExpressApp->>ExpressApp: "Validate req.body.name"
    ExpressApp->>User: "400 Bad Request (Correct)"

    User->>ExpressApp: "GET /resource6/:id"
    ExpressApp->>ResourceFinder: "findResource(id)"
    ResourceFinder-->>ExpressApp: "Resource not found"
    ExpressApp->>User: "404 Not Found (Correct)"

    User->>ExpressApp: "PUT /resource7/:id"
    ExpressApp->>AuthMiddleware: "Check req.user"
    AuthMiddleware-->>ExpressApp: "User not authenticated"
    ExpressApp->>User: "403 Forbidden (Wrong: should be 401)"

    User->>ExpressApp: "DELETE /resource8/:id"
    ExpressApp->>AuthMiddleware: "Check req.user"
    AuthMiddleware-->>ExpressApp: "User authenticated"
    ExpressApp->>PermissionCheck: "hasPermission(user, 'delete_resource')"
    PermissionCheck-->>ExpressApp: "Permission granted"
    ExpressApp->>User: "204 No Content (Correct)"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for HTTP status code handling across authentication, authorization, bad requests, not found, and resource operations (create, update, delete, retrieve).
  * Includes parallel “incorrect vs. correct” scenarios to validate proper responses (e.g., 401 vs. 403, 400, 404).

* **Chores**
  * No user-facing changes; runtime behavior and public interfaces remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->